### PR TITLE
add map to gatsby config

### DIFF
--- a/packages/gatsby/README.md
+++ b/packages/gatsby/README.md
@@ -22,6 +22,13 @@ module.exports = {
       options: {
         // public API Key
         publicAPIKey: 'MY_PUBLIC_API_KEY',
+        mapEntryToGatsbyConfig: (entry) => {
+          return {
+            property: entry.data.property,
+            anotherProperty: entry.data.whatever,
+            ...
+          };
+        }
         templates: {
           // `page` can be any model of choice, camelCased
           page: path.resolve('templates/my-page.tsx'),

--- a/packages/gatsby/README.md
+++ b/packages/gatsby/README.md
@@ -22,7 +22,7 @@ module.exports = {
       options: {
         // public API Key
         publicAPIKey: 'MY_PUBLIC_API_KEY',
-        mapEntryToGatsbyConfig: (entry) => {
+        mapEntryToContext: (entry) => {
           return {
             property: entry.data.property,
             anotherProperty: entry.data.whatever,

--- a/packages/gatsby/README.md
+++ b/packages/gatsby/README.md
@@ -26,7 +26,7 @@ module.exports = {
           return {
             property: entry.data.property,
             anotherProperty: entry.data.whatever,
-            ...
+            /* ... */
           };
         }
         templates: {

--- a/packages/gatsby/src/gatsby-node.js
+++ b/packages/gatsby/src/gatsby-node.js
@@ -129,15 +129,19 @@ const createPagesAsync = async (config, createPage, graphql, models, offsets) =>
     }
     if (config.filter) {
       entries = entries.filter(config.filter);
-    }
+    }    
     entries.forEach(entry => {
       if (entry.content.data.url && entry.content.published === `published`) {
+
+        let mappedProps = {}
+        if (config.mapEntryToGatsbyConfig) {
+          mappedProps = config.mapEntryToGatsbyConfig(entry)
+        }
+
         createPage({
           path: entry.content.data.url,
           component,
-          ...(config.globalContext && {
-            context: config.globalContext,
-          }),
+          context: {...(config.globalContext || {}), ...mappedProps}
         });
       }
     });

--- a/packages/gatsby/src/gatsby-node.js
+++ b/packages/gatsby/src/gatsby-node.js
@@ -129,19 +129,22 @@ const createPagesAsync = async (config, createPage, graphql, models, offsets) =>
     }
     if (config.filter) {
       entries = entries.filter(config.filter);
-    }    
+    }
     entries.forEach(entry => {
       if (entry.content.data.url && entry.content.published === `published`) {
 
-        let mappedProps = {}
+        let mappedProps = {};
         if (config.mapEntryToGatsbyConfig) {
-          mappedProps = config.mapEntryToGatsbyConfig(entry)
+          mappedProps = config.mapEntryToGatsbyConfig(entry);
         }
 
         createPage({
           path: entry.content.data.url,
           component,
-          context: {...(config.globalContext || {}), ...mappedProps}
+          context: {
+              ...(config.globalContext || {}),
+              ...mappedProps.
+          }
         });
       }
     });

--- a/packages/gatsby/src/gatsby-node.js
+++ b/packages/gatsby/src/gatsby-node.js
@@ -143,7 +143,7 @@ const createPagesAsync = async (config, createPage, graphql, models, offsets) =>
           component,
           context: {
               ...(config.globalContext || {}),
-              ...mappedProps.
+              ...mappedProps
           }
         });
       }

--- a/packages/gatsby/src/gatsby-node.js
+++ b/packages/gatsby/src/gatsby-node.js
@@ -134,8 +134,8 @@ const createPagesAsync = async (config, createPage, graphql, models, offsets) =>
       if (entry.content.data.url && entry.content.published === `published`) {
 
         let mappedProps = {};
-        if (config.mapEntryToGatsbyConfig) {
-          mappedProps = config.mapEntryToGatsbyConfig(entry);
+        if (config.mapEntryToContext) {
+          mappedProps = config.mapEntryToContext(entry);
         }
 
         createPage({


### PR DESCRIPTION
## Description

Adding more parameters to the page context will allow having more flexibility when creating page graphql queries. Right now the parameters allowed are either the ones that Gatsby adds to the context by default (like **path**), or the ones added statically through the **globalContext**.

Adding a callback to be able to map entry properties to Gatsby's page context object, allows for more flexibility when creating graphql queries, being able to query specific data based on the entry properties.

using this map:
![image](https://user-images.githubusercontent.com/40391767/97779013-a3533a00-1b7b-11eb-9114-665c9daa4942.png)

we are now able to use the locale parameter in the page graphql query.

![image](https://user-images.githubusercontent.com/40391767/97779072-0e9d0c00-1b7c-11eb-8c66-b16de11d72d5.png)
